### PR TITLE
Create native image on release

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -11,7 +11,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ghcr.io/tonikaru/lab2malls
+  IMAGE_NAME: ghcr.io/tonikaru/post-service
   VERSION: ${{ github.event.release.tag_name }}
 
 jobs:
@@ -59,7 +59,7 @@ jobs:
 
       - name: Push Docker image
         run: |
-          docker tag lab2malls:latest ${{ env.IMAGE_NAME }}:latest
+          docker tag post-service:latest ${{ env.IMAGE_NAME }}:latest
           docker push ${{ env.IMAGE_NAME }}:latest
-          docker tag lab2malls:latest ${{ env.IMAGE_NAME }}:${{ env.VERSION }}
+          docker tag post-service:latest ${{ env.IMAGE_NAME }}:${{ env.VERSION }}
           docker push ${{ env.IMAGE_NAME }}:${{ env.VERSION }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,65 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Create and publish a Native image
+
+on:
+  release:
+    types: [ published ]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ghcr.io/tonikaru/lab2malls
+  VERSION: ${{ github.event.release.tag_name }}
+
+jobs:
+  compile-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: maven
+
+  build-and-publish-executable-and-image:
+    needs: [ compile-and-test ]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: maven
+          
+      - name: Log into registry ${{ env.REGISTRY }}
+        uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+  
+      - name: Build a docker image
+        run: mvn package -Dpackaging=docker-native -Pgraalvm
+
+      - name: Push Docker image
+        run: |
+          docker tag lab2malls:latest ${{ env.IMAGE_NAME }}:latest
+          docker push ${{ env.IMAGE_NAME }}:latest
+          docker tag lab2malls:latest ${{ env.IMAGE_NAME }}:${{ env.VERSION }}
+          docker push ${{ env.IMAGE_NAME }}:${{ env.VERSION }}


### PR DESCRIPTION
Builds the image on release assuming we can create the image locally with "mvn package -Dpackaging=docker-native -Pgraalvm" 
Closes #4.